### PR TITLE
Add support for save and format on key combinations #1

### DIFF
--- a/src/GToolkit-Coder/GtMethodCoder.class.st
+++ b/src/GToolkit-Coder/GtMethodCoder.class.st
@@ -501,6 +501,12 @@ GtMethodCoder >> forMethod: aCompiledMethod [
 	methodSource := aCompiledMethod sourceCode
 ]
 
+{ #category : #updating }
+GtMethodCoder >> format [
+	methodSource := self patternSource , String cr , (RBParser parseExpression: self bodySource) formattedCode copyReplaceAll: String cr with: String cr , String tab.
+	self buildSource
+]
+
 { #category : #ui }
 GtMethodCoder >> gtLiveFor: aView [
 	<gtView>
@@ -615,6 +621,12 @@ GtMethodCoder >> newSourceEditor [
 		when: BrTextEditorDeletedEvent do: [ :event | self bodyChanged ];
 		when: BrTextEditorInsertedEvent do: [ :event | self bodyChanged ];
 		when: BlInfiniteDataSourceChanged do: [ :event | self bodyChanged ].
+	aSourceEditor interactions add: (BlShortcut new
+		combination: (BlKeyCombination builder primary; key: Key s; build);
+		action: [ self save ]).
+	aSourceEditor interactions add: (BlShortcut new
+		combination: (BlKeyCombination builder primary; shift; key: Key f; build);
+		action: [ self format ]).
 	^ aSourceEditor
 ]
 


### PR DESCRIPTION
This is a proof of concept for integrating save and format key combinations into coder, as a possible solution for #1 .

Note that it uses RBParser to get a formatted version of the code, that might not be desired in case formatting should be handled in GT.
The key combinations are hacked into newSourceEditor, there might be a better place to intialize a source code editor.
If there are key combinations, there should probably also be a menu action somewhere reachable through the UI.

Also, I am not quite what the desired way of contributing is. Are pull requests and issues fine, or is there another tracking system used that I should hook into?