### PR TITLE
Pop out a page into a new window (like in inspector). DO NOT INTEGRATE

### DIFF
--- a/src/GToolkit-Coder/GtCoderToolbarElement.class.st
+++ b/src/GToolkit-Coder/GtCoderToolbarElement.class.st
@@ -99,6 +99,7 @@ GtCoderToolbarElement >> initializeToolbarElement [
 		addItem: self newSpotterButton;
 		addItem: self newHierarchyButton;
 		addItem: self newAddButton;
+		addItem: self newPopOutButton;
 		yourself
 ]
 
@@ -106,14 +107,14 @@ GtCoderToolbarElement >> initializeToolbarElement [
 GtCoderToolbarElement >> newAddButton [
 	| look |
 	^ BrButton new
-		label: 'Add class or package';
+		label: 'Add (e.g. class or package)';
 		look:
 			BrGlamorousButtonWithIconLook
 				+
 					(look := BrGlamorousWithDropdownLook
 						handle: [ BrButton new
 								look:
-									BrGlamorousButtonWithIconLook - BrGlamorousButtonWithLabelTooltipLook
+									BrGlamorousButtonWithIconLook
 										- BrGlamorousButtonExteriorLook;
 								icon: BrGlamorousVectorIcons add;
 								yourself ]
@@ -153,7 +154,7 @@ GtCoderToolbarElement >> newHierarchyButton [
 		look: BrGlamorousButtonWithIconLook + (BrGlamorousWithDropdownLook
 			handle: [
 				BrButton new
-					look: BrGlamorousButtonWithIconLook - BrGlamorousButtonWithLabelTooltipLook - BrGlamorousButtonExteriorLook;
+					look: BrGlamorousButtonWithIconLook - BrGlamorousButtonExteriorLook;
 					icon: BrGlamorousIcons tree;
 					yourself ]
 			content: [
@@ -164,6 +165,16 @@ GtCoderToolbarElement >> newHierarchyButton [
 						asElement)
 			]);
 		icon: BrGlamorousIcons tree asElement;
+		yourself
+]
+
+{ #category : #'private - instance creation' }
+GtCoderToolbarElement >> newPopOutButton [
+	^ BrButton new
+		label: 'Browse in a new window';
+		look: BrGlamorousButtonWithIconLook;
+		icon: BrGlamorousIcons maximize asElement;
+		action: [ (GtCoder forClass: self navigationModel selectedClass) openInPager maximized ];
 		yourself
 ]
 


### PR DESCRIPTION
I "half" implemented it, but there are so many entry points into Coder (forClass:, forObject:, forPackage:, forCoder: - what could that last one even mean!?) that I'm not sure how to complete it, so I arbitrarily implemented the case where a class is selected. Maybe some double dispatch is warranted...

Also, it opens in a new window because that's what inspector does, but would a new tab be better? Not sure but the advantage of the latter is that AFAICT it's easy to go from tab -> window via the UI, but not the reverse.