### PR TITLE
Filters buttons

### DIFF
--- a/src/GToolkit-Coder-UI/GtFiltersElement.class.st
+++ b/src/GToolkit-Coder-UI/GtFiltersElement.class.st
@@ -164,21 +164,6 @@ GtFiltersElement >> descriptors: aCollection [
 	self updateAdditionalFilters
 ]
 
-{ #category : #accessing }
-GtFiltersElement >> filterButtonFor: descriptor icon: icon label: label [
-	^ BrButton new
-		aptitude: self defaultAptitude;
-		icon: icon;
-		label: label;
-		margin: (BlInsets all: 2);
-		beSmallSize;
-		hExact: 20;
-		constraintsDo: [ :c | c flow vertical alignCenter ];
-		action: [ :aButton | 
-			self addFilterForDescriptor: descriptor andValue: ''.
-			self applyFilters ]
-]
-
 { #category : #'api - filters' }
 GtFiltersElement >> filtersDo: aBlock [
 	"Iterate over all valid filters"

--- a/src/GToolkit-Coder-UI/GtFiltersElement.class.st
+++ b/src/GToolkit-Coder-UI/GtFiltersElement.class.st
@@ -20,7 +20,24 @@ GtFiltersElement >> addAllDefaults [
 			[:defaultDescriptor |
 			filterElement := self createFilterTagFor: defaultDescriptor.
 			filterElement makeDefaultFilter.
-			self addChild: filterElement at: self myChildrenCount]
+			self addChild: filterElement at: self nextTagPosition]
+]
+
+{ #category : #accessing }
+GtFiltersElement >> addFilterButtonFor: descriptor label: label icon: icon [
+	^ BrButton new
+		aptitude: self defaultAptitude;
+		icon: icon;
+		label: label;
+		margin: (BlInsets all: 2);
+		beSmallSize;
+		hExact: 20;
+		constraintsDo: [ :c | c flow vertical alignCenter ];
+		action: [ :aButton | 
+			(self filtersWithDescriptor: descriptor)
+				ifEmpty: [ self addFilterForDescriptor: descriptor andValue: '' ]
+				ifNotEmpty: [ :coll | coll do: [ :e | self removeChild: e ] ].
+			self applyFilters ]
 ]
 
 { #category : #accessing }
@@ -28,7 +45,17 @@ GtFiltersElement >> addFilterForDescriptor: aFilterDescriptor andValue: aString 
 	| element |
 	element := self createFilterTagFor: aFilterDescriptor.
 	aFilterDescriptor valueIsRequired ifTrue: [element valueString: aString].
-	self addChild: element at: self myChildrenCount
+	self addChild: element at: self nextTagPosition
+]
+
+{ #category : #accessing }
+GtFiltersElement >> additionalDefaultButtons [
+	| sortedPragmas |
+	sortedPragmas := (Pragma allNamed: #gtFilterElement: in: self class)
+			sort: [ :aPragma | aPragma arguments first ] ascending
+					, [ :aPragma | aPragma methodSelector ] ascending.
+	^ (sortedPragmas collect: [ :e | self perform: e methodSelector ])
+		reject: [ :e | e isNil ]
 ]
 
 { #category : #private }
@@ -90,7 +117,7 @@ GtFiltersElement >> createNewTag [
 			[:items |
 			"self areAllDefaults ifTrue: [ self clearFilters ]."
 			tag := self createFilterTagFor: items first.
-			self addChild: tag at: self myChildrenCount.
+			self addChild: tag at: self nextTagPosition.
 			tag activateEditor]
 ]
 
@@ -115,7 +142,9 @@ GtFiltersElement >> defaultAptitude [
 
 { #category : #accessing }
 GtFiltersElement >> defaultButtonCount [
-	^1 + self myFilterButtons size
+	| addButton |
+	addButton := self childWithId: GtFiltersAddButtonId.
+	^ self childrenCount - (self childIndexOf: addButton) + 1
 ]
 
 { #category : #accessing }
@@ -127,10 +156,27 @@ GtFiltersElement >> descriptors [
 { #category : #accessing }
 GtFiltersElement >> descriptors: aCollection [
 	descriptors := aCollection.
-	
+
 	BlFrameTelemetry
 		time: [ 'Add default filter tag' ]
-		during: [ self addAllDefaults ]
+		during: [ self addAllDefaults ].
+
+	self updateAdditionalFilters
+]
+
+{ #category : #accessing }
+GtFiltersElement >> filterButtonFor: descriptor icon: icon label: label [
+	^ BrButton new
+		aptitude: self defaultAptitude;
+		icon: icon;
+		label: label;
+		margin: (BlInsets all: 2);
+		beSmallSize;
+		hExact: 20;
+		constraintsDo: [ :c | c flow vertical alignCenter ];
+		action: [ :aButton | 
+			self addFilterForDescriptor: descriptor andValue: ''.
+			self applyFilters ]
 ]
 
 { #category : #'api - filters' }
@@ -148,21 +194,30 @@ GtFiltersElement >> filtersDo: aBlock [
 ]
 
 { #category : #accessing }
+GtFiltersElement >> filtersWithDescriptor: aDescriptor [
+	| result |
+	result := OrderedCollection new.
+	1
+		to: self childrenCount - self defaultButtonCount
+		do: [ :i | 
+			| filterTagElement |
+			filterTagElement := self childAt: i.
+			filterTagElement descriptor = aDescriptor
+				ifTrue: [ result add: filterTagElement ] ].
+	^ result
+]
+
+{ #category : #accessing }
 GtFiltersElement >> gtTestFilter [
 	<gtFilterElement: 10>
-	^ BrButton new
-		id: GtFiltersAddButtonId;
-		aptitude: self defaultAptitude;
-		icon: BrGlamorousVectorIcons down;
-		label: 'Add Filter';
-		margin: (BlInsets all: 2);
-		beSmallSize;
-		hExact: 20;
-		constraintsDo: [ :c | c flow vertical alignCenter ];
-		action: [ :aButton | self createNewTag ];
-		addShortcut: (BlShortcutWithAction new
-				combination: BlKeyCombination enter;
-				action: [ :anEvent | self createNewTag ])
+	| descriptor |
+	descriptor := self descriptors
+			detect: [ :e | e name = 'Instance methods' ]
+			ifNone: [ ^ nil ].
+	^ self
+		addFilterButtonFor: descriptor
+		label: 'Add instance methods filter'
+		icon: BrGlamorousVectorIcons emphasizedInspect
 ]
 
 { #category : #'gt - extensions' }
@@ -186,20 +241,7 @@ GtFiltersElement >> initialize [
 	self hMatchParent.
 	self vFitContent.
 	self addChild: self newAddTagButton.
-	self myFilterButtons do: [:e | self addChild: e]
-]
-
-{ #category : #accessing }
-GtFiltersElement >> myChildrenCount [
-	^self childrenCount - self defaultButtonCount + 1
-]
-
-{ #category : #accessing }
-GtFiltersElement >> myFilterButtons [
-	^ (Pragma allNamed: #gtFilterElement: in: self class)
-		sort: [ :aPragma | aPragma arguments first ] ascending
-				, [ :aPragma | aPragma methodSelector ] ascending;
-		collect: [ :e | self perform: e methodSelector ]
+	self updateAdditionalFilters
 ]
 
 { #category : #'private - instance creation' }
@@ -217,4 +259,17 @@ GtFiltersElement >> newAddTagButton [
 		addShortcut: (BlShortcutWithAction new
 				combination: BlKeyCombination enter;
 				action: [ :anEvent | self createNewTag ])
+]
+
+{ #category : #accessing }
+GtFiltersElement >> nextTagPosition [
+	^self childrenCount - self defaultButtonCount + 1
+]
+
+{ #category : #accessing }
+GtFiltersElement >> updateAdditionalFilters [
+	[ self defaultButtonCount > 1 ]
+		whileTrue: [ self removeChildAt: self childrenCount - 1 ].
+
+	self additionalDefaultButtons do: [ :e | self addChild: e ]
 ]

--- a/src/GToolkit-Coder-UI/GtFiltersElement.class.st
+++ b/src/GToolkit-Coder-UI/GtFiltersElement.class.st
@@ -11,26 +11,24 @@ Class {
 	#category : #'GToolkit-Coder-UI-Filters'
 }
 
-{ #category : #private }
+{ #category : #accessing }
 GtFiltersElement >> addAllDefaults [
 	| filterElement defaultDescriptors |
-	
-	defaultDescriptors := self descriptors select: [ :each | each showAsDefaultWhenEmpty ].
-	defaultDescriptors
-		do: [ :defaultDescriptor | 
+	defaultDescriptors := self descriptors
+				select: [:each | each showAsDefaultWhenEmpty].
+	defaultDescriptors do: 
+			[:defaultDescriptor |
 			filterElement := self createFilterTagFor: defaultDescriptor.
 			filterElement makeDefaultFilter.
-
-			self addChild: filterElement at: self childrenCount ]
+			self addChild: filterElement at: self myChildrenCount]
 ]
 
 { #category : #accessing }
 GtFiltersElement >> addFilterForDescriptor: aFilterDescriptor andValue: aString [
 	| element |
 	element := self createFilterTagFor: aFilterDescriptor.
-	aFilterDescriptor valueIsRequired
-		ifTrue: [ element valueString: aString ].
-	self addChild: element at: self childrenCount
+	aFilterDescriptor valueIsRequired ifTrue: [element valueString: aString].
+	self addChild: element at: self myChildrenCount
 ]
 
 { #category : #private }
@@ -43,11 +41,11 @@ GtFiltersElement >> applyFiltersDueTo: aReason [
 	self fireEvent: (GtFiltersChangedEvent new filterElement: self; reason: aReason)
 ]
 
-{ #category : #private }
+{ #category : #accessing }
 GtFiltersElement >> areAllDefaults [
-	^ self childrenCount > 1
-		and: [ (1 to: self childrenCount - 1)
-				allSatisfy: [ :index | (self childAt: index) isDefaultAllFilter ] ]
+	^self childrenCount > self defaultButtonCount and: 
+			[(1 to: self childrenCount - self defaultButtonCount)
+				allSatisfy: [:index | (self childAt: index) isDefaultAllFilter]]
 ]
 
 { #category : #'api - filters' }
@@ -70,11 +68,11 @@ GtFiltersElement >> buildFilters: aBlock [
 	aBlock value
 ]
 
-{ #category : #'api - filters' }
+{ #category : #accessing }
 GtFiltersElement >> clearFilters [
 	"Remove all filters"
-
-	[ self childrenCount > 1 ] whileTrue: [ self removeChildAt: 1 ]
+	[self childrenCount > self defaultButtonCount]
+		whileTrue: [self removeChildAt: 1]
 ]
 
 { #category : #'private - instance creation' }
@@ -88,17 +86,36 @@ GtFiltersElement >> createFilterTagFor: aFilterDescription [
 { #category : #private }
 GtFiltersElement >> createNewTag [
 	| tag |
-	self descriptors
-		ifNotEmpty: [ :items | 
+	self descriptors ifNotEmpty: 
+			[:items |
 			"self areAllDefaults ifTrue: [ self clearFilters ]."
 			tag := self createFilterTagFor: items first.
-			self addChild: tag at: self childrenCount.
-			tag activateEditor ]
+			self addChild: tag at: self myChildrenCount.
+			tag activateEditor]
 ]
 
 { #category : #'api - filters' }
 GtFiltersElement >> currentFilters [
 	^ Array streamContents: [ :aStream | self filtersDo: [ :eachFilter :eachValue | aStream nextPut: (eachFilter -> eachValue) ] ]
+]
+
+{ #category : #'private - instance creation' }
+GtFiltersElement >> defaultAptitude [
+	^ BrGlamorousButtonRectangularAptitude new + BrGlamorousButtonIconAptitude new
+		+ BrGlamorousButtonWithLabelTooltipAptitude new
+		+ (BrStyleCommonAptitude new
+				default: [ :aStyle | 
+					aStyle
+						border: BlBorder empty;
+						background: self theme status neutralBackgroundColor ];
+				hovered: [ :aStyle | aStyle background: self theme status neutralBackgroundColor darker ];
+				pressed: [ :aStyle | aStyle background: self theme status neutralBackgroundColor darker darker ];
+				focused: [ :aStyle | aStyle border: (BlBorder paint: self theme editor focusedBorderColor width: 1) ])
+]
+
+{ #category : #accessing }
+GtFiltersElement >> defaultButtonCount [
+	^1 + self myFilterButtons size
 ]
 
 { #category : #accessing }
@@ -119,14 +136,33 @@ GtFiltersElement >> descriptors: aCollection [
 { #category : #'api - filters' }
 GtFiltersElement >> filtersDo: aBlock [
 	"Iterate over all valid filters"
+	1 to: self childrenCount - self defaultButtonCount
+		do: 
+			[:i |
+			| filterTagElement |
+			filterTagElement := self childAt: i.
+			filterTagElement isValid
+				ifTrue: 
+					[aBlock value: filterTagElement descriptor
+						value: filterTagElement valueString]]
+]
 
-	1 to: self childrenCount - 1 do: [ :i | 
-		| filterTagElement |
-		filterTagElement := self childAt: i.
-		filterTagElement isValid
-			ifTrue: [ aBlock
-					value: filterTagElement descriptor
-					value: filterTagElement valueString ] ]
+{ #category : #accessing }
+GtFiltersElement >> gtTestFilter [
+	<gtFilterElement: 10>
+	^ BrButton new
+		id: GtFiltersAddButtonId;
+		aptitude: self defaultAptitude;
+		icon: BrGlamorousVectorIcons down;
+		label: 'Add Filter';
+		margin: (BlInsets all: 2);
+		beSmallSize;
+		hExact: 20;
+		constraintsDo: [ :c | c flow vertical alignCenter ];
+		action: [ :aButton | self createNewTag ];
+		addShortcut: (BlShortcutWithAction new
+				combination: BlKeyCombination enter;
+				action: [ :anEvent | self createNewTag ])
 ]
 
 { #category : #'gt - extensions' }
@@ -149,28 +185,28 @@ GtFiltersElement >> initialize [
 	super initialize.
 	self hMatchParent.
 	self vFitContent.
-	self addChild: self newAddTagButton
+	self addChild: self newAddTagButton.
+	self myFilterButtons do: [:e | self addChild: e]
+]
+
+{ #category : #accessing }
+GtFiltersElement >> myChildrenCount [
+	^self childrenCount - self defaultButtonCount + 1
+]
+
+{ #category : #accessing }
+GtFiltersElement >> myFilterButtons [
+	^ (Pragma allNamed: #gtFilterElement: in: self class)
+		sort: [ :aPragma | aPragma arguments first ] ascending
+				, [ :aPragma | aPragma methodSelector ] ascending;
+		collect: [ :e | self perform: e methodSelector ]
 ]
 
 { #category : #'private - instance creation' }
 GtFiltersElement >> newAddTagButton [
 	^ BrButton new
 		id: GtFiltersAddButtonId;
-		aptitude:
-			BrGlamorousButtonRectangularAptitude new
-				+ BrGlamorousButtonIconAptitude new
-				+ BrGlamorousButtonWithLabelTooltipAptitude new
-				+ (BrStyleCommonAptitude new
-						default: [ :aStyle | 
-							aStyle
-								border: BlBorder empty;
-								background: self theme status neutralBackgroundColor ];
-						hovered: [ :aStyle | 
-							aStyle background: self theme status neutralBackgroundColor darker ];
-						pressed: [ :aStyle | 
-							aStyle background: self theme status neutralBackgroundColor darker darker ];
-						focused: [ :aStyle | 
-							aStyle border: (BlBorder paint: self theme editor focusedBorderColor width: 1) ]);
+		aptitude: self defaultAptitude;
 		icon: BrGlamorousVectorIcons add;
 		label: 'Add Filter';
 		margin: (BlInsets all: 2);
@@ -178,8 +214,7 @@ GtFiltersElement >> newAddTagButton [
 		hExact: 20;
 		constraintsDo: [ :c | c flow vertical alignCenter ];
 		action: [ :aButton | self createNewTag ];
-		addShortcut:
-			(BlShortcutWithAction new
+		addShortcut: (BlShortcutWithAction new
 				combination: BlKeyCombination enter;
 				action: [ :anEvent | self createNewTag ])
 ]


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/a667d32d-7471-4568-a179-482980f17a97)
I implemented a feature that allows to quickly add and remove filters without having to use the dropdown menu, making the process more seamless and faster. As implemented now there is an example for the "instance methods" filters as shown in the screenshot. By clicking on the button, the filter is added and then removed by clicking again.