### PR TITLE
Source Coder Attribute message is not caring about receiving the shortcuts

### DIFF
--- a/src/GToolkit-Coder-UI/GtSourceCoderErrorAttribute.class.st
+++ b/src/GToolkit-Coder-UI/GtSourceCoderErrorAttribute.class.st
@@ -49,9 +49,11 @@ GtSourceCoderErrorAttribute >> doAffect: aTBrTextEditorTextualPiece in: anEditor
 								textElement := BlTextElement new.
 								textElement text: text.
 								textElement padding: (BlInsets all: 10).
+								textElement beFocusable.
 								textElement
 									when: BlClickEvent
 									do: [ :event | clickAction cull: anEditorElement cull: aptitude hide ].
+
 								{BlKeyCombination escape.
 									BlKeyCombination enter.
 									BlKeyCombination backspace}


### PR DESCRIPTION
On parsing error, the textElement displaying the message should be focuseable to accept shortcuts

![image](https://github.com/user-attachments/assets/a8ed4430-77ee-4de6-bde9-3479480a26cc)

for instance ESCAPE should make the red message disappear