### PR TITLE
Fix the node selection in the coder

### DIFF
--- a/src/GToolkit-Coder/GtCoderClassesHierarchyTree.class.st
+++ b/src/GToolkit-Coder/GtCoderClassesHierarchyTree.class.st
@@ -100,16 +100,16 @@ GtCoderClassesHierarchyTree >> gtTreeFor: aView [
 		expandUpTo: 1
 ]
 
+{ #category : #comparing }
+GtCoderClassesHierarchyTree >> hash [
+	^ self rootClass hash bitXor: self subclassTrees hash
+]
+
 { #category : #testing }
 GtCoderClassesHierarchyTree >> hasRootClass [
 	<return: #Boolean>
 
 	^ rootClass isNotNil
-]
-
-{ #category : #comparing }
-GtCoderClassesHierarchyTree >> hash [
-	^ self rootClass hash bitXor: self subclassTrees hash
 ]
 
 { #category : #initialization }

--- a/src/GToolkit-Coder/GtCoderNavigationModel.class.st
+++ b/src/GToolkit-Coder/GtCoderNavigationModel.class.st
@@ -66,21 +66,6 @@ GtCoderNavigationModel >> selectClasses: aCollectionOfClasses [
 ]
 
 { #category : #'api - selection' }
-GtCoderNavigationModel >> selectMethod: aCompiledMethod [
-	self subclassResponsibility
-]
-
-{ #category : #'api - selection' }
-GtCoderNavigationModel >> selectMethods: aCollectionOfCompiledMethods [
-	self subclassResponsibility
-]
-
-{ #category : #'api - selection' }
-GtCoderNavigationModel >> selectPackage: aPackage [
-	self subclassResponsibility
-]
-
-{ #category : #'api - selection' }
 GtCoderNavigationModel >> selectedClassDo: aBlock [
 	self subclassResponsibility
 ]
@@ -92,6 +77,21 @@ GtCoderNavigationModel >> selectedPackageDo: aBlock [
 
 { #category : #'api - selection' }
 GtCoderNavigationModel >> selectedTagDo: aBlock [
+	self subclassResponsibility
+]
+
+{ #category : #'api - selection' }
+GtCoderNavigationModel >> selectMethod: aCompiledMethod [
+	self subclassResponsibility
+]
+
+{ #category : #'api - selection' }
+GtCoderNavigationModel >> selectMethods: aCollectionOfCompiledMethods [
+	self subclassResponsibility
+]
+
+{ #category : #'api - selection' }
+GtCoderNavigationModel >> selectPackage: aPackage [
 	self subclassResponsibility
 ]
 

--- a/src/GToolkit-Coder/GtCoderNullNavigationModel.class.st
+++ b/src/GToolkit-Coder/GtCoderNullNavigationModel.class.st
@@ -52,21 +52,6 @@ GtCoderNullNavigationModel >> selectClasses: aCollectionOfClasses [
 ]
 
 { #category : #'api - selection' }
-GtCoderNullNavigationModel >> selectMethod: aCompiledMethod [
-	"do nothing"
-]
-
-{ #category : #'api - selection' }
-GtCoderNullNavigationModel >> selectMethodProtocol: aMethodProtocol [
-	"do nothing"
-]
-
-{ #category : #'api - selection' }
-GtCoderNullNavigationModel >> selectPackage: aPackage [
-	"do nothing"
-]
-
-{ #category : #'api - selection' }
 GtCoderNullNavigationModel >> selectedClassDo: aBlock [
 	"do nothing"
 ]
@@ -83,5 +68,20 @@ GtCoderNullNavigationModel >> selectedPackageDo: aBlock [
 
 { #category : #'api - selection' }
 GtCoderNullNavigationModel >> selectedTagDo: aBlock [
+	"do nothing"
+]
+
+{ #category : #'api - selection' }
+GtCoderNullNavigationModel >> selectMethod: aCompiledMethod [
+	"do nothing"
+]
+
+{ #category : #'api - selection' }
+GtCoderNullNavigationModel >> selectMethodProtocol: aMethodProtocol [
+	"do nothing"
+]
+
+{ #category : #'api - selection' }
+GtCoderNullNavigationModel >> selectPackage: aPackage [
 	"do nothing"
 ]

--- a/src/GToolkit-Coder/GtDiffSplit.class.st
+++ b/src/GToolkit-Coder/GtDiffSplit.class.st
@@ -14,14 +14,14 @@ GtDiffSplit >> = anObject [
 	^ self class = anObject class ifTrue: [ self object = anObject object ]
 ]
 
-{ #category : #testing }
-GtDiffSplit >> hasMatch [
-	^ matched
-]
-
 { #category : #comparing }
 GtDiffSplit >> hash [
 	^ self object hash
+]
+
+{ #category : #testing }
+GtDiffSplit >> hasMatch [
+	^ matched
 ]
 
 { #category : #initialization }

--- a/src/GToolkit-Coder/GtPackagesCompletionStrategy.class.st
+++ b/src/GToolkit-Coder/GtPackagesCompletionStrategy.class.st
@@ -15,6 +15,17 @@ GtPackagesCompletionStrategy class >> allPackagesDo: aBlock [
 ]
 
 { #category : #querying }
+GtPackagesCompletionStrategy class >> findPackagesMatching: aString [
+	| searchString results |
+	searchString := '*' , aString , '*'.
+	results := OrderedCollection new.
+	self allPackagesDo: [ :each | 
+		(searchString match: each name)
+			ifTrue: [ results add: each ] ].
+	^ results
+]
+
+{ #category : #querying }
 GtPackagesCompletionStrategy class >> findPackageTagsMatching: aString [
 	| searchString results |
 	searchString := '*' , aString , '*'.
@@ -24,17 +35,6 @@ GtPackagesCompletionStrategy class >> findPackageTagsMatching: aString [
 			do: [ :tag | 
 				(searchString match: tag categoryName)
 					ifTrue: [ results add: tag ] ] ].
-	^ results
-]
-
-{ #category : #querying }
-GtPackagesCompletionStrategy class >> findPackagesMatching: aString [
-	| searchString results |
-	searchString := '*' , aString , '*'.
-	results := OrderedCollection new.
-	self allPackagesDo: [ :each | 
-		(searchString match: each name)
-			ifTrue: [ results add: each ] ].
 	^ results
 ]
 

--- a/src/GToolkit-Coder/GtRefactoryChangeManager.class.st
+++ b/src/GToolkit-Coder/GtRefactoryChangeManager.class.st
@@ -58,17 +58,17 @@ GtRefactoryChangeManager >> addUndo: aChange [
 	self announceUndoChanged
 ]
 
+{ #category : #announcer }
+GtRefactoryChangeManager >> announcer [
+	^ announcer ifNil: [ announcer := Announcer new ]
+]
+
 { #category : #executing }
 GtRefactoryChangeManager >> announceUndoChanged [
 	self
 		announce: (GtRefactoryChangeManagerUndoChangedEvent new
 				changeManager: self;
 				yourself)
-]
-
-{ #category : #announcer }
-GtRefactoryChangeManager >> announcer [
-	^ announcer ifNil: [ announcer := Announcer new ]
 ]
 
 { #category : #accessing }

--- a/src/GToolkit-Coder/GtSourceCoder.class.st
+++ b/src/GToolkit-Coder/GtSourceCoder.class.st
@@ -295,10 +295,10 @@ GtSourceCoder >> nodeFrom: aCoderViewModel [
 	| allSelections allCursors |
 	allSelections := aCoderViewModel selection allSelections.
 	allCursors := aCoderViewModel cursors allCursors.
-
-	^ allSelections size = 1
-		ifTrue: [ self nodeWithin: allSelections first interval ]
-		ifFalse: [ allCursors size = 1 ifTrue: [ self nodeAt: allCursors first position ] ]
+	^allSelections size = 1
+		ifTrue: [self nodeWithin: aCoderViewModel selectedTextInterval]
+		ifFalse: 
+			[allCursors size = 1 ifTrue: [self nodeAt: allCursors first position]]
 ]
 
 { #category : #accessing }


### PR DESCRIPTION
The interval of the selection is containing 1 more item that it should. SelectedTextInterval is considering one less character at start.

This is helping the selection be consistent for some refactorings.
![image](https://github.com/user-attachments/assets/5e576f4f-8ca8-4237-b5e9-ece3a1b77604)
is now equivalent to:
![image](https://github.com/user-attachments/assets/1c0a37e7-d065-42a4-b099-a8b0aa7488ab)

(This PR only change GtSourceCoder >> nodeFrom: aCoderViewModel )

